### PR TITLE
Fix stops sorting function

### DIFF
--- a/lua/snippy.lua
+++ b/lua/snippy.lua
@@ -92,8 +92,12 @@ local function sort_stops(stops)
         elseif s2.id == 0 then
             return true
         end
-        return s1.id < s2.id
-            or util.is_before(s1.startpos, s2.startpos)
+        if s1.id < s2.id then
+            return true
+        elseif s1.id > s2.id then
+            return false
+        end
+        return util.is_before(s1.startpos, s2.startpos)
     end)
 end
 

--- a/lua/snippy/util.lua
+++ b/lua/snippy/util.lua
@@ -9,11 +9,11 @@ local function print_error(...)
 end
 
 local function is_after(pos1, pos2)
-    return pos1[1] < pos2[1] or (pos1[2] == pos1[2] and pos1[1] < pos2[1])
+    return pos1[1] > pos2[1] or (pos1[1] == pos2[1] and pos1[2] > pos2[2])
 end
 
 local function is_before(pos1, pos2)
-    return pos1[1] < pos2[1] or (pos1[2] == pos1[2] and pos1[1] < pos2[1])
+    return pos1[1] < pos2[1] or (pos1[1] == pos2[1] and pos1[2] < pos2[2])
 end
 
 local function t(input)


### PR DESCRIPTION
Fix for stops sorting function. In some cases Lua is complaining that the function is invalid.

Fixed issues:
 - `is_before` and `is_after` functions were exactly the same, `is_after` is not used anywere as far as I can tell, but still.
 - above functions were also broken, as they were basically just checking if line is lower, if not, it was checking if column of first step is the same as column of the same step, which was always true, and then if line was lower (same check as at beginning).
 - `sort_step` itself was also wrong as, for my snippet it generated steps like this:
   ```
   s1:{
     endpos = { 3, 7 },
     id = 4,
     startpos = { 3, 3 },
     type = "placeholder"
   }
   s2:{
     endpos = { 4, 1 },
     id = 3,
     placeholder = "",
     startpos = { 4, 1 },
     type = "tabstop"
   }
   ```
   Given previous logic sorting function was returning true when `(s1, s2)` was passed because `s1` (line 3) is before `s2` (line 4). It was also true when `(s2, s1)` was called as `s2.id < s1.id`. Lua apparently don't like that behaviour and is throwing exception *"invalid order function for sorting"*.

Snippet that was causing me the issues (stripped down version):
```
${1:var1}
${2:var2} ${3:var3}
$2 $3 $3 ${4:var4}
$3 $3 $4
```
