### PR TITLE
Implement some snippet modifiers

### DIFF
--- a/doc/snippy.txt
+++ b/doc/snippy.txt
@@ -110,13 +110,22 @@ Files with the `.snippet` extension contain a single snippet, while files with
 the `.snippets` extension can be used to declare multiple snippets using the
 following format:
 >
-    snippet trigger1 "Description for snippet 1"
+    snippet trigger1 "Description for snippet 1" [option]
     	This is the first line.
     	This is the second line.
-    snippet trigger2 "Description for snippet 2"
+    snippet trigger2 "Description for snippet 2" [option]
     	This is the first line.
     	This is the second line.
 <
+The `option`s control the behavior of the expansion of the snippet and are
+optional. Currently supported are the following:
+    - `w` Word boundary - The word expands only when the trigger is on a word
+        boundary. This is the default behavior.
+    - `i` In-word expansion - The snippet gets expanded even if the trigger is
+        only part of the word, up to the cursor.
+    - `b` Beginning of line - The snippet is only expanded if its trigger is
+        the first word on the line, only preceeded by whitespace.
+
                                                       *snippy-usage-indenting*
 
 Make sure each line in the snippet definition is indented with spaces or tabs

--- a/lua/snippy.lua
+++ b/lua/snippy.lua
@@ -145,7 +145,7 @@ local function get_snippet_at_cursor()
     M.read_snippets()
     local _, col = unpack(api.nvim_win_get_cursor(0))
 
-    -- remove leading whitespace for current_line_to_col
+    -- Remove leading whitespace for current_line_to_col
     local current_line_to_col =
         api.nvim_get_current_line():sub(1, col):match('(%S+)$')
 

--- a/lua/snippy.lua
+++ b/lua/snippy.lua
@@ -146,8 +146,7 @@ local function get_snippet_at_cursor()
     local _, col = unpack(api.nvim_win_get_cursor(0))
 
     -- Remove leading whitespace for current_line_to_col
-    local current_line_to_col =
-        api.nvim_get_current_line():sub(1, col):match('(%S+)$')
+    local current_line_to_col = api.nvim_get_current_line():sub(1, col):match('(%S+)$')
 
     if current_line_to_col then
         word = current_line_to_col:match('(%S+)$') -- remove leading whitespace
@@ -158,23 +157,21 @@ local function get_snippet_at_cursor()
                 if scope and M.snippets[scope] then
                     if M.snippets[scope][word] then
                         local snippet = M.snippets[scope][word]
-                        if snippet.option == "i" then
+                        if snippet.option == 'i' then
                             -- match inside word
                             return word, snippet
-                        elseif snippet.option == "b" then
+                        elseif snippet.option == 'b' then
                             -- match if word is first on line
                             if word == current_line_to_col then
                                 return word, snippet
                             end
-                        elseif snippet.option == "w" or snippet.option == "" then
+                        elseif snippet.option == 'w' or snippet.option == '' then
                             if word_bound then
                                 -- by default only match on word boundary
                                 return word, snippet
                             end
                         else
-                            error( string.format(
-                                "Unknown option %s in snippet %s",
-                                snippet.option, snippet.prefix))
+                            error(string.format('Unknown option %s in snippet %s', snippet.option, snippet.prefix))
                         end
                     end
                 end

--- a/lua/snippy.lua
+++ b/lua/snippy.lua
@@ -158,23 +158,23 @@ local function get_snippet_at_cursor()
                 if scope and M.snippets[scope] then
                     if M.snippets[scope][word] then
                         local snippet = M.snippets[scope][word]
-                        if snippet.modifier == "i" then
+                        if snippet.option == "i" then
                             -- match inside word
                             return word, snippet
-                        elseif snippet.modifier == "b" then
+                        elseif snippet.option == "b" then
                             -- match if word is first on line
                             if word == current_line_to_col then
                                 return word, snippet
                             end
-                        elseif snippet.modifier == "w" or snippet.modifier == "" then
+                        elseif snippet.option == "w" or snippet.option == "" then
                             if word_bound then
                                 -- by default only match on word boundary
                                 return word, snippet
                             end
                         else
                             error( string.format(
-                                "Unkown modifier %s in snippet %s",
-                                snippet.modifier, snippet.prefix))
+                                "Unknown option %s in snippet %s",
+                                snippet.option, snippet.prefix))
                         end
                     end
                 end

--- a/lua/snippy.lua
+++ b/lua/snippy.lua
@@ -144,23 +144,43 @@ end
 local function get_snippet_at_cursor()
     M.read_snippets()
     local _, col = unpack(api.nvim_win_get_cursor(0))
-    local current_line = api.nvim_get_current_line()
-    local word = current_line:sub(1, col):match('(%S+)$')
-    if word then
+
+    -- remove leading whitespace for current_line_to_col
+    local current_line_to_col =
+        api.nvim_get_current_line():sub(1, col):match('(%S+)$')
+
+    if current_line_to_col then
+        word = current_line_to_col:match('(%S+)$') -- remove leading whitespace
+        local word_bound = true
         local scopes = shared.get_scopes()
         while #word > 0 do
             for _, scope in ipairs(scopes) do
                 if scope and M.snippets[scope] then
                     if M.snippets[scope][word] then
-                        return word, M.snippets[scope][word]
+                        local snippet = M.snippets[scope][word]
+                        if snippet.modifier == "i" then
+                            -- match inside word
+                            return word, snippet
+                        elseif snippet.modifier == "b" then
+                            -- match if word is first on line
+                            if word == current_line_to_col then
+                                return word, snippet
+                            end
+                        elseif snippet.modifier == "w" or snippet.modifier == "" then
+                            if word_bound then
+                                -- by default only match on word boundary
+                                return word, snippet
+                            end
+                        else
+                            error( string.format(
+                                "Unkown modifier %s in snippet %s",
+                                snippet.modifier, snippet.prefix))
+                        end
                     end
                 end
             end
-            if word:match('^%w') then
-                word = word:gsub('^%w+', '')
-            else
-                word = word:sub(2)
-            end
+            word = word:sub(2)
+            word_bound = false
         end
     end
     return nil, nil

--- a/lua/snippy/reader/snipmate.lua
+++ b/lua/snippy/reader/snipmate.lua
@@ -27,7 +27,8 @@ local function read_snippets_file(snippets_file)
         local line = lines[i]
         local prefix = line:match('%s+(%S+)%s*')
         assert(prefix, 'prefix is nil: ' .. line .. ', file: ' .. snippets_file)
-        local description = line:match('%s*"(.+)"%s*$')
+        local description = line:match('%s*"(.+)"%s*')
+        local modifier = line:match('[bwi]?$') -- allow at most one modifier
         local body = {}
         local indent = nil
         i = i + 1
@@ -54,6 +55,7 @@ local function read_snippets_file(snippets_file)
             kind = 'snipmate',
             prefix = prefix,
             description = description,
+            modifier = modifier,
             body = body,
         }
     end

--- a/lua/snippy/reader/snipmate.lua
+++ b/lua/snippy/reader/snipmate.lua
@@ -28,7 +28,7 @@ local function read_snippets_file(snippets_file)
         local prefix = line:match('%s+(%S+)%s*')
         assert(prefix, 'prefix is nil: ' .. line .. ', file: ' .. snippets_file)
         local description = line:match('%s*"(.+)"%s*')
-        local modifier = line:match('[bwi]?$') -- allow at most one modifier
+        local option = line:match('[bwi]?$') -- allow at most one option
         local body = {}
         local indent = nil
         i = i + 1
@@ -55,7 +55,7 @@ local function read_snippets_file(snippets_file)
             kind = 'snipmate',
             prefix = prefix,
             description = description,
-            modifier = modifier,
+            option = option,
             body = body,
         }
     end

--- a/test/unit/reader_spec.lua
+++ b/test/unit/reader_spec.lua
@@ -9,8 +9,8 @@ describe('Snippet reader', function()
         snippy.setup({ snippet_dirs = './test/snippets/' })
         vim.cmd('set filetype=')
         local snips = {
-            test1 = { kind = 'snipmate', prefix = 'test1', body = { 'This is the first test.' } },
-            test2 = { kind = 'snipmate', prefix = 'test2', body = { 'This is the second test.' } },
+            test1 = { kind = 'snipmate', prefix = 'test1', option = '', body = { 'This is the first test.' } },
+            test2 = { kind = 'snipmate', prefix = 'test2', option = '', body = { 'This is the second test.' } },
         }
         assert.is_truthy(require('snippy.shared').config.snippet_dirs)
         assert.is_not.same({}, require('snippy.reader.snipmate').list_available_scopes())
@@ -24,6 +24,7 @@ describe('Snippet reader', function()
             no_description = {
                 kind = 'snipmate',
                 prefix = 'no_description',
+                option = '',
                 body = {
                     'This is a *.snippet file with no description.',
                 },
@@ -31,6 +32,7 @@ describe('Snippet reader', function()
             trigger = {
                 kind = 'snipmate',
                 prefix = 'trigger',
+                option = '',
                 description = 'description',
                 body = {
                     'This is a *.snippet file with a description.',
@@ -48,6 +50,7 @@ describe('Snippet reader', function()
             trigger = {
                 kind = 'snipmate',
                 prefix = 'trigger',
+                option = '',
                 body = {
                     'This is indented with two spaces.',
                     '\tThis is indented with four spaces.',

--- a/test/unit/reader_spec.lua
+++ b/test/unit/reader_spec.lua
@@ -24,7 +24,6 @@ describe('Snippet reader', function()
             no_description = {
                 kind = 'snipmate',
                 prefix = 'no_description',
-                option = '',
                 body = {
                     'This is a *.snippet file with no description.',
                 },
@@ -32,7 +31,6 @@ describe('Snippet reader', function()
             trigger = {
                 kind = 'snipmate',
                 prefix = 'trigger',
-                option = '',
                 description = 'description',
                 body = {
                     'This is a *.snippet file with a description.',


### PR DESCRIPTION
This adds the snippet modifier `i`, `b`, and `w`, to allow snippets to only be expanded on certain conditions:
- `i`: snippets may be expanded even if inside a word
- `b`: snippets may be expanded only if their word boundary is on the beginning of the line, ignoring whitespace
- `w`: snippets may only be expanded if the snippet matches on the word boundary

This addresses parts of issue #35.