### PR TITLE
Fix else path of example S-Tab mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ For example, to use `<Tab>` to expand and jump forward, `<S-Tab` to jump back:
 
 ```vim
 imap <expr> <Tab> snippy#can_expand_or_advance() ? '<Plug>(snippy-expand-or-advance)' : '<Tab>'
-imap <expr> <S-Tab> snippy#can_jump(-1) ? '<Plug>(snippy-previous)' : '<Tab>'
+imap <expr> <S-Tab> snippy#can_jump(-1) ? '<Plug>(snippy-previous)' : '<S-Tab>'
 smap <expr> <Tab> snippy#can_jump(1) ? '<Plug>(snippy-next)' : '<Tab>'
-smap <expr> <S-Tab> snippy#can_jump(-1) ? '<Plug>(snippy-previous)' : '<Tab>'
+smap <expr> <S-Tab> snippy#can_jump(-1) ? '<Plug>(snippy-previous)' : '<S-Tab>'
 xmap <Tab> <Plug>(snippy-cut-text)
 ```
 


### PR DESCRIPTION
Hello,

I noticed a small typo in the `README.md` while experimenting with `snippy` in my local config, and thought I'd send a fix.
Example mappings using `<S-Tab>` to jump back had `<Tab>` in the ternary else branch, instead of `<S-Tab>`.

P.S. Thanks for this nice, simple plugin and for the `cmp` integrations :)