### PR TITLE
Set empty options for snipmate .snippet file

### DIFF
--- a/lua/snippy/reader/snipmate.lua
+++ b/lua/snippy/reader/snipmate.lua
@@ -153,6 +153,7 @@ local function read_snippet_file(snippet_file, scope)
             description = description,
             -- Priority for .snippet is always 0
             priority = 0,
+            option = {},
             body = body,
         },
     }

--- a/test/unit/reader_spec.lua
+++ b/test/unit/reader_spec.lua
@@ -45,6 +45,7 @@ describe('Snippet reader', function()
                 kind = 'snipmate',
                 prefix = 'no_description',
                 priority = 0,
+                option = {},
                 body = {
                     'This is a *.snippet file with no description.',
                 },
@@ -54,6 +55,7 @@ describe('Snippet reader', function()
                 prefix = 'trigger',
                 description = 'description',
                 priority = 0,
+                option = {},
                 body = {
                     'This is a *.snippet file with a description.',
                 },


### PR DESCRIPTION
`can_expand_or_advance()` calls `get_snippet_at_cursor()` which access
option field for autotrigger configuration. It will trigger an error
for snipmate .snippet snippet if option field is not set.

```
E5108: Error executing lua ...e/nvim/site/pack/packer/start/nvim-snippy/lua/snippy.lua:188: attempt to index field 'option' (a nil value)                                             
stack traceback:                                                                                                                                                                      
        ...e/nvim/site/pack/packer/start/nvim-snippy/lua/snippy.lua:188: in function 'get_snippet_at_cursor'                                                                          
        ...e/nvim/site/pack/packer/start/nvim-snippy/lua/snippy.lua:511: in function 'can_expand'                                                                                     
        ...e/nvim/site/pack/packer/start/nvim-snippy/lua/snippy.lua:529: in function 'can_expand_or_advance' 
```

Offending line is [here](https://github.com/dcampos/nvim-snippy/blob/master/lua/snippy.lua#L188), with global autotrigger turned off (default setting).

