### PR TITLE
Add custom expand options

### DIFF
--- a/doc/snippy.txt
+++ b/doc/snippy.txt
@@ -149,6 +149,27 @@ optional. Currently supported are the following:
         this feature, because it checks every key pressed, may theoretically
         affect the performance of your editor when used.
 
+Custom `option`s can be defined via the setup option `expand_options` to restrict
+expansion in specific scenarios. For example, consider latex snippets which
+should only be expanded when inside of a math environment or in comments:
+>
+    expand_options = {
+        m = function()
+            return vim.fn["vimtex#syntax#in_mathzone"]() == 1
+        end,
+        c = function()
+            return vim.fn["vimtex#syntax#in_comment"]() == 1
+        end,
+    }
+<
+Snippets with the above custom expand `option`s can then be written:
+>
+    snippet trigger1 "Description for snippet in mathzone" m
+        ...
+    snippet trigger2 "Description for autosnippet in comment" Ac
+        ...
+<
+
                                                       *snippy-usage-indenting*
 
 Make sure each line in the snippet definition is indented with spaces or tabs
@@ -448,6 +469,12 @@ mappings~
     | next                | snippy.mapping.Next              |
     | previous            | snippy.mapping.Previous          |
     | cut_text            | snippy.mapping.CutText           |
+
+expand_options~
+    Add new `option`s to limit triggering in certain scenarios. See
+    |snippy-snippet-options|.
+        Type: `Table`
+        Default: {}
 
 
 ==============================================================================

--- a/lua/snippy/main.lua
+++ b/lua/snippy/main.lua
@@ -168,22 +168,28 @@ local function get_snippet_at_cursor(auto_trigger)
                             auto_trigger and snippet.option.auto_trigger
                             or not auto_trigger and not snippet.option.auto_trigger
                         then
-                            if snippet.option.inword then
-                                -- Match inside word
-                                return word, snippet
-                            elseif snippet.option.beginning then
-                                -- Match if word is first on line
-                                if word == current_line_to_col then
+                            local custom_expand = true
+                            for k,v in pairs(snippet.option.custom) do
+                                custom_expand = custom_expand and v()
+                            end
+                            if custom_expand then
+                                if snippet.option.inword then
+                                    -- Match inside word
                                     return word, snippet
-                                end
-                            elseif snippet.option.word then
-                                if word == kword then
-                                    return word, snippet
-                                end
-                            else
-                                if word_bound then
-                                    -- By default only match on word boundary
-                                    return word, snippet
+                                elseif snippet.option.beginning then
+                                    -- Match if word is first on line
+                                    if word == current_line_to_col then
+                                        return word, snippet
+                                    end
+                                elseif snippet.option.word then
+                                    if word == kword then
+                                        return word, snippet
+                                    end
+                                else
+                                    if word_bound then
+                                        -- By default only match on word boundary
+                                        return word, snippet
+                                    end
                                 end
                             end
                         end

--- a/lua/snippy/main.lua
+++ b/lua/snippy/main.lua
@@ -169,8 +169,10 @@ local function get_snippet_at_cursor(auto_trigger)
                             or not auto_trigger and not snippet.option.auto_trigger
                         then
                             local custom_expand = true
-                            for k,v in pairs(snippet.option.custom) do
-                                custom_expand = custom_expand and v()
+                            if snippet.option.custom then
+                                for k, v in pairs(snippet.option.custom) do
+                                    custom_expand = custom_expand and v()
+                                end
                             end
                             if custom_expand then
                                 if snippet.option.inword then

--- a/lua/snippy/reader/snipmate.lua
+++ b/lua/snippy/reader/snipmate.lua
@@ -22,9 +22,14 @@ local function parse_options(prefix, line)
     local beginning = opt:find('b') and true
     local auto = opt:find('A') and true
 
-    local invalid = opt:match('[^bwiA]')
-    if invalid then
-        error(string.format('Unknown option %s in snippet %s', invalid, prefix))
+    local custom = {}
+    local invalid = false
+    for sym in opt:gmatch('[^bwiA]') do
+      if not shared.config.expand_options[sym] then
+        error(string.format('Unknown option %s in snippet %s', sym, prefix))
+      else
+        custom[sym] = shared.config.expand_options[sym]
+      end
     end
 
     assert(
@@ -37,6 +42,7 @@ local function parse_options(prefix, line)
         inword = inword,
         beginning = beginning,
         auto_trigger = auto,
+        custom = custom
     }
 end
 

--- a/lua/snippy/reader/snipmate.lua
+++ b/lua/snippy/reader/snipmate.lua
@@ -25,11 +25,11 @@ local function parse_options(prefix, line)
     local custom = {}
     local invalid = false
     for sym in opt:gmatch('[^bwiA]') do
-      if not shared.config.expand_options[sym] then
-        error(string.format('Unknown option %s in snippet %s', sym, prefix))
-      else
-        custom[sym] = shared.config.expand_options[sym]
-      end
+        if not shared.config.expand_options[sym] then
+            error(string.format('Unknown option %s in snippet %s', sym, prefix))
+        else
+            custom[sym] = shared.config.expand_options[sym]
+        end
     end
 
     assert(
@@ -42,7 +42,7 @@ local function parse_options(prefix, line)
         inword = inword,
         beginning = beginning,
         auto_trigger = auto,
-        custom = custom
+        custom = custom,
     }
 end
 

--- a/lua/snippy/shared.lua
+++ b/lua/snippy/shared.lua
@@ -29,6 +29,7 @@ local default_config = {
     mappings = {},
     choice_delay = 100,
     enable_auto = false,
+    expand_options = {},
 }
 
 M.get_scopes = get_scopes

--- a/test/functional/snippy_spec.lua
+++ b/test/functional/snippy_spec.lua
@@ -16,6 +16,13 @@ describe('Snippy', function()
             snippy.setup({
                 snippet_dirs = '%s',
                 enable_auto = true,
+                expand_options = {
+                  c = function()
+                    local cur_row,cur_col = vim.api.nvim_win_get_cursor(0)
+                    local first_char = vim.api.nvim_buf_get_text(0,cur_row-1,0,cur_row-1,1,{})
+                    return first_char == "#"
+                  end
+                }
             })]],
             alter_slashes(snippy_src .. '/test/snippets/')
         ))
@@ -733,6 +740,37 @@ describe('Snippy', function()
         screen:expect({
             grid = [[
           foo begin^                                         |
+          {1:~                                                 }|
+          {1:~                                                 }|
+          {1:~                                                 }|
+          {2:-- INSERT --}                                      |
+        ]],
+        })
+    end)
+
+    it('should expand with custom option', function()
+        setup_test_snippets()
+        command('set filetype=python')
+        insert('comment')
+        feed('a')
+        feed('<plug>(snippy-expand)')
+        screen:expect({
+            grid = [[
+          comment^                                           |
+          {1:~                                                 }|
+          {1:~                                                 }|
+          {1:~                                                 }|
+          {2:-- INSERT --}                                      |
+        ]],
+        })
+        feed('<Esc>:%d<CR>')
+        insert('# comment')
+        feed('a')
+        feed('<plug>(snippy-expand)')
+        -- screen:snapshot_util()
+        screen:expect({
+            grid = [[
+          # Expand this if on a commented line!^             |
           {1:~                                                 }|
           {1:~                                                 }|
           {1:~                                                 }|

--- a/test/functional/snippy_spec.lua
+++ b/test/functional/snippy_spec.lua
@@ -18,9 +18,7 @@ describe('Snippy', function()
                 enable_auto = true,
                 expand_options = {
                   c = function()
-                    local cur_row,cur_col = vim.api.nvim_win_get_cursor(0)
-                    local first_char = vim.api.nvim_buf_get_text(0,cur_row-1,0,cur_row-1,1,{})
-                    return first_char == "#"
+                      return vim.startswith(vim.api.nvim_get_current_line(), '#')
                   end
                 }
             })]],

--- a/test/snippets/python.snippets
+++ b/test/snippets/python.snippets
@@ -4,5 +4,7 @@ snippet inword "Test inword" i
 	Expand this inside a word!
 snippet word "Test word" w
 	Expand this if it is keyword based!
+snippet comment "Test custome expand (comment)" c
+	Expand this if on a commented line!
 snippet default "Test default"
 	Expand only if space-delimited word present!

--- a/test/unit/reader_spec.lua
+++ b/test/unit/reader_spec.lua
@@ -76,7 +76,7 @@ describe('Snippet reader', function()
             trigger = {
                 kind = 'snipmate',
                 prefix = 'trigger',
-                option = {},
+                option = { custom = {} },
                 description = 'description',
                 priority = 0,
                 body = {
@@ -96,8 +96,8 @@ describe('Snippet reader', function()
         vim.cmd('set filetype=java')
         assert.is_truthy(require('snippy.shared').config.snippet_dirs)
         assert.is_not.same({}, require('snippy.reader.snipmate').list_available_scopes())
-        assert.is_same({ beginning = true }, snippy.snippets.java.cls.option)
-        assert.is_same({ auto_trigger = true }, snippy.snippets.java.psvm.option)
+        assert.is_same({ beginning = true, custom = {} }, snippy.snippets.java.cls.option)
+        assert.is_same({ auto_trigger = true, custom = {} }, snippy.snippets.java.psvm.option)
     end)
 
     it('can read vim-snippets snippets', function()


### PR DESCRIPTION
Based on the ideas behind the expand options: i,A,b,w to limit triggering an expansion to certain scenarios, this commit allows for user-defined expand options. The user definition in the `setup` function should define the option letter as a key and a function to be called with no arguments to determine if expansion is possible.

The custom expand options are currently given priority over i,A,b,w to ensure they are not ignored.

A test for custom expand option (commented line) has been created, but I found it difficult to set up the neovim/vusted/busted environment to verify it. I have however tested it for my use case with latex snippet expansion within math equations and it is working well. #75 