### PR TITLE
Improve lazy loading of snippets

### DIFF
--- a/plugin/snippy.vim
+++ b/plugin/snippy.vim
@@ -30,7 +30,6 @@ endfunction
 
 augroup Snippy
     autocmd!
-    autocmd FileType,InsertEnter * lua require 'snippy.main'.read_snippets()
     autocmd BufWritePost *.snippet{,s} lua require 'snippy.main'.clear_cache()
     autocmd OptionSet *runtimepath* lua require 'snippy.main'.clear_cache()
 augroup END

--- a/test/unit/reader_spec.lua
+++ b/test/unit/reader_spec.lua
@@ -1,10 +1,6 @@
 local snippy = require('snippy')
 
 describe('Snippet reader', function()
-    setup(function()
-        vim.cmd([[runtime! plugin/snippy.vim]])
-    end)
-
     before_each(function()
         snippy.clear_cache()
     end)


### PR DESCRIPTION
Currently, snippets are loaded with a filetype autocmd, but that means they are loaded on startup. This change removes the autocmd and changes the loading to only occur on demand.