### PR TITLE
Fix Windows-Path Bug

### DIFF
--- a/lua/snippy/reader/snipmate.lua
+++ b/lua/snippy/reader/snipmate.lua
@@ -178,6 +178,9 @@ local function list_dirs()
     if local_dir and fn.isdirectory(local_dir) then
         table.insert(dirs, 1, fn.fnamemodify(local_dir, ':p'))
     end
+    for key,dir in ipairs(dirs) do
+        dirs[key] = vim.fn.substitute(dir, '\\\\$', '', 'g')
+    end
     if type(dirs) ~= 'string' then
         dirs = table.concat(dirs, ',')
     end

--- a/lua/snippy/reader/snipmate.lua
+++ b/lua/snippy/reader/snipmate.lua
@@ -178,7 +178,7 @@ local function list_dirs()
     if local_dir and fn.isdirectory(local_dir) then
         table.insert(dirs, 1, fn.fnamemodify(local_dir, ':p'))
     end
-    for key,dir in ipairs(dirs) do
+    for key, dir in ipairs(dirs) do
         dirs[key] = vim.fn.substitute(dir, '\\\\$', '', 'g')
     end
     if type(dirs) ~= 'string' then


### PR DESCRIPTION
Unfortunately, `vim.fn.globpath` cannot handle directory paths with trailing backslashes (even though it returns them with one). Example:

``` lua
--[[ Structure
    c:\temp\reprod
    | dir1
    |  | snippets
    |  |  | lua.snippets
    | dir2
    |  | snippets
    |  |  | lua.snippets --]]

snip_dirs = vim.fn.globpath('c:\\temp\\reprod\\dir1,c:\\temp\\reprod\\dir2', 'snippets/', 0, 1)
-- { "c:\\temp\\reprod\\dir1\\snippets\\", "c:\\temp\\reprod\\dir2\\snippets\\" }

dirs = table.concat(dirs, ',')
-- "c:\\temp\\reprod\\dir1\\snippets\\,c:\\temp\\reprod\\dir2\\snippets\\"

snip_files = vim.fn.globpath("c:\\temp\\reprod\\dir1\\snippets\\,c:\\temp\\reprod\\dir2\\snippets\\","*.snippets",0,1)
-- BUG: { }

snip_files = vim.fn.globpath("c:\\temp\\reprod\\dir1\\snippets,c:\\temp\\reprod\\dir2\\snippets","*.snippets",0,1)
-- works: { "c:\\temp\\reprod\\dir1\\snippets\\lua.snippets", "c:\\temp\\reprod\\dir2\\snippets\\lua.snippets" }
```