### PR TITLE
Set keyword-based trigger as default

### DIFF
--- a/doc/snippy.txt
+++ b/doc/snippy.txt
@@ -162,8 +162,7 @@ allows snippets to be conveniently separated by a single blank line.
 The `option`s control the behavior of the expansion of the snippet and are
 optional. Currently supported are the following:
     - `w` Word boundary - The word expands only when the trigger is on a word
-        boundary. A |word| in this context is a sequence of |iskeyword|
-        characters.
+        boundary. This is the default behavior.
     - `i` In-word expansion - The snippet gets expanded even if the trigger is
         only part of the word, up to the cursor.
     - `b` Beginning of line - The snippet is only expanded if its trigger is
@@ -173,13 +172,9 @@ optional. Currently supported are the following:
         this feature, because it checks every key pressed, may theoretically
         affect the performance of your editor when used.
 
-Note that the default behavior is to only expand if the whole |WORD|
-(space-delimited) before the cursor matches the trigger.
-
-Custom `option`s can be defined via the setup option `expand_options` to
-restrict expansion in specific scenarios. For example, consider latex snippets
-which should only be expanded when inside of a math environment or in
-comments:
+Custom `option`s can be defined via the setup option `expand_options` to restrict
+expansion in specific scenarios. For example, consider latex snippets which
+should only be expanded when inside of a math environment or in comments:
 >lua
     expand_options = {
         m = function()

--- a/lua/snippy/main.lua
+++ b/lua/snippy/main.lua
@@ -167,7 +167,6 @@ local function get_snippet_at_cursor(auto_trigger)
         end
 
         local word = current_line_to_col:match('(%S*)$') -- Remove leading whitespace
-        local kword = fn.matchstr(word, '\\k\\+$')
         local word_bound = true
         local scopes = shared.get_scopes()
         while #word > 0 do
@@ -194,10 +193,6 @@ local function get_snippet_at_cursor(auto_trigger)
                                     if word == current_line_to_col then
                                         return word, snippet
                                     end
-                                elseif snippet.option.word then
-                                    if word == kword then
-                                        return word, snippet
-                                    end
                                 else
                                     if word_bound then
                                         -- By default only match on word boundary
@@ -209,8 +204,8 @@ local function get_snippet_at_cursor(auto_trigger)
                     end
                 end
             end
-            word = word:sub(2)
-            word_bound = false
+            word_bound = fn.match(word, '^\\k') == -1
+            word = fn.strcharpart(word, 1)
         end
     end
     return nil, nil

--- a/test/functional/snippy_spec.lua
+++ b/test/functional/snippy_spec.lua
@@ -844,12 +844,12 @@ describe('Snippy', function()
         })
         -- Don't expand this
         feed('<Esc>:%d<CR>')
-        insert('@@@default')
+        insert('foodefault')
         feed('a')
         feed('<plug>(snippy-expand)')
         screen:expect({
             grid = [[
-          @@@Expand if keyword-delimited word present!^      |
+          foodefault^                                        |
           {1:~                                                 }|
           {1:~                                                 }|
           {1:~                                                 }|

--- a/test/functional/snippy_spec.lua
+++ b/test/functional/snippy_spec.lua
@@ -835,7 +835,7 @@ describe('Snippy', function()
         feed('<plug>(snippy-expand)')
         screen:expect({
             grid = [[
-          foo Expand only if space-delimited word present!^  |
+          foo Expand if keyword-delimited word present!^     |
           {1:~                                                 }|
           {1:~                                                 }|
           {1:~                                                 }|
@@ -849,7 +849,7 @@ describe('Snippy', function()
         feed('<plug>(snippy-expand)')
         screen:expect({
             grid = [[
-          @@@default^                                        |
+          @@@Expand if keyword-delimited word present!^      |
           {1:~                                                 }|
           {1:~                                                 }|
           {1:~                                                 }|

--- a/test/snippets/python.snippets
+++ b/test/snippets/python.snippets
@@ -7,4 +7,4 @@ snippet word "Test word" w
 snippet comment "Test custome expand (comment)" c
 	Expand this if on a commented line!
 snippet default "Test default"
-	Expand only if space-delimited word present!
+	Expand if keyword-delimited word present!


### PR DESCRIPTION
Closes #119.

This makes Snippy's default behavior compatible with Ultisnips and SnipMate.