### PR TITLE
feat(SnippyEdit): open snippet file on curret ft

### DIFF
--- a/plugin/snippy.lua
+++ b/plugin/snippy.lua
@@ -34,8 +34,18 @@ local function complete_snippet_files(lead, _, _)
 end
 
 command('SnippyEdit', function(params)
-    vim.cmd(params.mods .. [[ split ]] .. vim.fn.fnameescape(params.args))
-end, { nargs = 1, complete = complete_snippet_files })
+    if (vim.fn.empty(params.args)) then
+        local slash = vim.fn.exists("+shellslash") == 1 and '\\' or '/'
+        local path = vim.fn.stdpath("config") .. slash .. snippets
+        if (not (vim.uv or vim.loop).fs_stat(path)) then
+            vim.fn.mkdir(path, 'p')
+        end
+        local file = path .. slash .. vim.bo.ft .. ".snippets"
+        vim.cmd(params.mods .. [[ split ]] .. vim.fn.fnameescape(file))
+    else
+        vim.cmd(params.mods .. [[ split ]] .. vim.fn.fnameescape(params.args))
+    end
+end, { nargs = '?', complete = complete_snippet_files })
 
 command('SnippyReload', function()
     require('snippy').clear_cache()


### PR DESCRIPTION
Hi,
this PR makes SnippyEdit open directly the corresponding snippet file, of the current filetype, when is called without arguments.

Calling `SnippyEdit` on a cpp file will result in opening `$XDG_CONFIG_HOME/nvim/snippets/cpp.snippets`.

This is very helpfull when creating snippets while editing a file. I have a mapping to open quickly my snippets, edit them and then continue working. 