### PR TITLE
fix: initialize M.selected_text with nil

### DIFF
--- a/lua/snippy/shared.lua
+++ b/lua/snippy/shared.lua
@@ -50,7 +50,7 @@ local default_config = {
 }
 
 M.get_scopes = get_scopes
-M.selected_text = ''
+M.selected_text = nil
 M.namespace = vim.api.nvim_create_namespace('snippy')
 M.config = vim.tbl_extend('force', {}, default_config)
 M.buffer_config = {}


### PR DESCRIPTION
If M.selected_text starts out as an empty string, then snippets like the following won't work properly at the start of a new editing session.

	snippet it "italics"
		*${1:${TM_SELECTED_TEXT:text}}*