### PR TITLE
Use non-deprecated version of `vim.validate()`

### DIFF
--- a/lua/snippy/shared.lua
+++ b/lua/snippy/shared.lua
@@ -89,9 +89,13 @@ function M.set_selection(value, mode)
 end
 
 function M.set_config(params)
-    vim.validate({
-        params = { params, 't' },
-    })
+    if vim.fn.has('nvim-0.11') == 1 then
+        vim.validate('params', params, 'table')
+    else
+        vim.validate({
+            params = { params, 't' },
+        })
+    end
     if params.snippet_dirs then
         local dirs = params.snippet_dirs
         local dir_list = type(dirs) == 'table' and dirs or vim.split(dirs, ',')
@@ -135,10 +139,15 @@ function M.set_config(params)
 end
 
 function M.set_buffer_config(bufnr, params)
-    vim.validate({
-        bufnr = { bufnr, 'n' },
-        params = { params, 't' },
-    })
+    if vim.fn.has('nvim-0.11') == 1 then
+        vim.validate('bufnr', bufnr, 'number')
+        vim.validate('params', params, 'table')
+    else
+        vim.validate({
+            bufnr = { bufnr, 'n' },
+            params = { params, 't' },
+        })
+    end
     M.buffer_config[vim.fn.bufnr(bufnr)] = params
 end
 


### PR DESCRIPTION
Since NeoVim 0.11, `vim.validate()` has a new signature which uses less tables, is more performant and easier to read. The old signature is considered deprecated and is targeted for removal in NeoVim 1.0. Even though we won't see NeoVim 1.0 soon, it's somewhat annoying to trigger deprecation warnings each time the plugin is loaded.

This patch adds a condition to two places where `vim.validate()` is used, using the new signature on NeoVim 0.11 and above.